### PR TITLE
Replace deprecated function 'create_function'

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -42,7 +42,7 @@ $level_options = get_privacy_level_options();
 // sizes
 $type_map = ImageStdParams::get_defined_type_map();
 $sizes_keys = array_keys($type_map);
-$sizes_names = array_map(create_function('$s', 'return l10n($s);'), $sizes_keys);
+$sizes_names = array_map(function ($s) {return l10n($s);}, $sizes_keys);
 
 $sizes_options = array_combine($sizes_keys, $sizes_names);
 $sizes_options['original'] = l10n('Original');

--- a/include/BatchDownloader.class.php
+++ b/include/BatchDownloader.class.php
@@ -297,7 +297,7 @@ SELECT image_id, filemtime
 ;';
       $registered = array_from_query($query, 'image_id', 'filemtime');
 
-      $to_update = array_filter($registered, create_function('$t', 'return $t<'.$last_mod_time.';'));
+      $to_update = array_filter($registered, function ($t) use ($last_mod_time) {return $t<$last_mod_time;});
       $to_update = array_merge($to_update, array_diff($image_ids, $registered));
     }
 
@@ -412,10 +412,10 @@ DELETE FROM '.IMAGE_SIZES_TABLE.'
     $filename = str_replace($search, $replace, $this->conf['file_pattern']);
 
     // functions
-    $filename = preg_replace_callback('#\$escape\((.*?)\)#', create_function('$m', 'return str2url($m[1]);'),   $filename);
-    $filename = preg_replace_callback('#\$upper\((.*?)\)#',  create_function('$m', 'return str2upper($m[1]);'), $filename);
-    $filename = preg_replace_callback('#\$lower\((.*?)\)#',  create_function('$m', 'return str2lower($m[1]);'), $filename);
-    $filename = preg_replace_callback('#\$strpad\((.*?),(.*?),(.*?)\)#', create_function('$m', 'return str_pad($m[1],$m[2],$m[3],STR_PAD_LEFT);'), $filename);
+    $filename = preg_replace_callback('#\$escape\((.*?)\)#', function ($m) {return str2url($m[1]);},   $filename);
+    $filename = preg_replace_callback('#\$upper\((.*?)\)#',  function ($m) {return str2upper($m[1]);}, $filename);
+    $filename = preg_replace_callback('#\$lower\((.*?)\)#',  function ($m) {return str2lower($m[1]);}, $filename);
+    $filename = preg_replace_callback('#\$strpad\((.*?),(.*?),(.*?)\)#', function ($m) {return str_pad($m[1],$m[2],$m[3],STR_PAD_LEFT);}, $filename);
 
     // cleanup
     $filename = preg_replace(

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -37,7 +37,7 @@ function get_set_info_from_page()
       break;
     case 'tags':
       $batch_type = 'tags';
-      $batch_id = implode(',', array_map(create_function('$t', 'return $t["id"];'), $page['tags']));
+      $batch_id = implode(',', array_map(function ($t) {return $t["id"];}, $page['tags']));
       break;
     case 'search':
       $batch_type = 'search';


### PR DESCRIPTION
This should fix #23.
To ensure compatibility with PHP 7.2 I replaced every occurrence of the deprecated function 'create_function' with anonymous functions.